### PR TITLE
refactor: respell the doas as doAs in the webhdfs api

### DIFF
--- a/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
+++ b/desktop/libs/hadoop/src/hadoop/fs/webhdfs.py
@@ -214,7 +214,7 @@ class WebHdfs(Hdfs):
   def _getparams(self):
     return {
       "user.name": WebHdfs.DEFAULT_USER,
-      "doas": self.user
+      "doAs": self.user
     }
 
   def _getheaders(self):

--- a/tdp/README.md
+++ b/tdp/README.md
@@ -69,7 +69,7 @@ Generate a `tar.gz` file of the release in the local `target/` folder:
 ```sh
 cd -
 mv /opt/tdp/hue /opt/tdp/hue-release-4.11.0
-tar cvzf /opt/tdp/hue-release-4.11.0-cp38-cp38-manylinux2014_x86_64.tar.gz -C /opt/tdp/ hue-release-4.11.0
+tar cvzf /opt/tdp/hue-release-4.11.0-2.0-cp38-cp38-manylinux2014_x86_64.tar.gz -C /opt/tdp/ hue-release-4.11.0
 ```
 
 **Note**: [Cloudera](https://docs.cloudera.com/cdp-private-cloud-base/7.1.8/installation/topics/cdpdc-install-python-3-centos.html) states to install a compiled Python with the shared library option enabled which is not the case in the [manylinux image](https://github.com/pypa/manylinux/blob/main/docker/build_scripts/build-cpython.sh#L36).


### PR DESCRIPTION

In order to correctly work with knox spnego gateway, the doas in the webhdfs api must be spelled `doAs` instead of `doas` so  that it is correctly transmitted in the url.

This change also works when connecting hue directly to the httpfs as before.